### PR TITLE
Custom port option for database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ Description: the password for the database user (above)
 Type: `String`
 Description: the hostname for the location in which the database resides. Typically this will be `localhost`
 
+#### port
+Type: `Integer`
+Description: the port that MySQL is running on. Defaults to `3306`
+
 #### url
 Type: `String`
 Description: the string to search and replace within the database before it is moved to the target location. Typically this is designed for use with systems such as WordPress where the `siteurl` value is [stored in the database](http://codex.wordpress.org/Changing_The_Site_URL) and is required to be updated upon migration to a new environment. It is however suitable for replacing any single value within the database before it is moved.

--- a/tasks/deployments.js
+++ b/tasks/deployments.js
@@ -142,7 +142,8 @@ module.exports = function(grunt) {
                 user: config.user,
                 pass: config.pass,
                 database: config.database,
-                path: src
+                path: src,
+                port: config.port || 3306
             }
         });
 
@@ -187,7 +188,8 @@ module.exports = function(grunt) {
                 user: config.user,
                 pass: config.pass,
                 database: config.database,
-                host: config.host
+                host: config.host,
+                port: config.port || 3306
             }
         });
 
@@ -249,9 +251,9 @@ module.exports = function(grunt) {
 
         search_replace: "sed -i '' 's#<%= search %>#<%= replace %>#g' <%= path %>",
 
-        mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> <%= database %>",
+        mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> -P<%= port %> <%= database %>",
 
-        mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> <%= database %>",
+        mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> -P<%= port %> <%= database %>",
 
         ssh: "ssh <%= host %>",
     };


### PR DESCRIPTION
I use MAMP for local development which runs MySQL on port `8889` rather than the standard `3306`. This PR adds the option to specify a custom port for the database connection. Hopefully it will help others in a similar situation.

My previous PR https://github.com/getdave/grunt-deployments/pull/26 was against master, this one is against develop as requested.
