### PR TITLE
Added support for custom SSH ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ All other targets *must* contain a valid `ssh_host` parameter.
   "host": "development_db_host",
   "url": "development_db_url",
   "ssh_host": "ssh_user@ssh_host",
+  "ssh_port": "ssh_port",
   "ignoreTables": ["table1","table2",...]
 },
 "stage": {
@@ -125,6 +126,7 @@ All other targets *must* contain a valid `ssh_host` parameter.
   "host": "stage_db_host",
   "url": "stage_db_url",
   "ssh_host": "ssh_user@ssh_host",
+  "ssh_port": "ssh_port",
   "ignoreTables": ["table1","table2",...]
 },
 "production": {
@@ -135,6 +137,7 @@ All other targets *must* contain a valid `ssh_host` parameter.
   "host": "production_db_host",
   "url": "production_db_url",
   "ssh_host": "ssh_user@ssh_host",
+  "ssh_port": "ssh_port",
   "ignoreTables": ["table1","table2",...]
 }
 ```
@@ -169,6 +172,7 @@ grunt.initConfig({
       "host": "development_db_host",
       "url": "development_db_url",
       "ssh_host": "ssh_user@ssh_host",
+      "ssh_port": "ssh_port",
       "ignoreTables": ["table1","table2",...]
     },
     "stage": {
@@ -179,6 +183,7 @@ grunt.initConfig({
       "host": "stage_db_host",
       "url": "stage_db_url",
       "ssh_host": "ssh_user@ssh_host",
+      "ssh_port": "ssh_port",
       "ignoreTables": ["table1","table2",...]
     },
     "production": {
@@ -189,6 +194,7 @@ grunt.initConfig({
       "host": "production_db_host",
       "url": "production_db_url",
       "ssh_host": "ssh_user@ssh_host",
+      "ssh_port": "ssh_port",
       "ignoreTables": ["table1","table2",...]
     }
   },
@@ -229,7 +235,12 @@ Description: the string to search and replace within the database before it is m
 
 #### ssh_host
 Type: `String`
-Description: ssh connection string in the format `SSH_USER@SSH_HOST`. The task assumes you have ssh keys setup which allow you to remote into your server without requiring the input of a password. As this is an exhaustive topic we will not cover it here but you might like to start by reading [Github's own advice](https://help.github.com/articles/generating-ssh-keys).
+Description: SSH connection string in the format `SSH_USER@SSH_HOST`. The task assumes you have SSH keys setup which allow you to remote into your server without requiring the input of a password. As this is an exhaustive topic we will not cover it here but you might like to start by reading [Github's own advice](https://help.github.com/articles/generating-ssh-keys).
+
+#### ssh_port
+Type: `String`
+Default value: `22`
+Description: SSH port number in the format `#####`. If you leave this off for a remote connection, the plugin will default to the standard SSH port of `22`.
 
 #### ignoreTables
 Type: `Array of Strings`

--- a/lib/dbDump.js
+++ b/lib/dbDump.js
@@ -40,12 +40,24 @@ function dbDump(config, output_paths, noExec) {
         cmd = tpl_mysqldump;
 
     } else { // it's a remote connection
-        var tpl_ssh = grunt.template.process(tpls.ssh, {
-            data: {
-                host: config.ssh_host,
-                port: config.ssh_port
-            }
-        });
+
+        // Test whether an SSH port is defined and pass the default port '22' if it's not defined
+        if (typeof config.ssh_port === "undefined") {
+            var tpl_ssh = grunt.template.process(tpls.ssh, {
+                data: {
+                    host: config.ssh_host,
+                    port: '22'
+                }
+            });
+        } else {
+            var tpl_ssh = grunt.template.process(tpls.ssh, {
+                data: {
+                    host: config.ssh_host,
+                    port: config.ssh_port
+                }
+            });
+        }
+
         grunt.log.writeln("Creating dump of remote database");
 
         cmd = tpl_ssh + " \\ " + tpl_mysqldump;

--- a/lib/dbDump.js
+++ b/lib/dbDump.js
@@ -42,7 +42,8 @@ function dbDump(config, output_paths, noExec) {
     } else { // it's a remote connection
         var tpl_ssh = grunt.template.process(tpls.ssh, {
             data: {
-                host: config.ssh_host
+                host: config.ssh_host,
+                port: config.ssh_port
             }
         });
         grunt.log.writeln("Creating dump of remote database");

--- a/lib/dbImport.js
+++ b/lib/dbImport.js
@@ -30,12 +30,23 @@ function dbImport(config, src) {
         grunt.log.writeln("Importing into local database");
         cmd = tpl_mysql + " < " + src;
     } else { // it's a remote connection
-        var tpl_ssh = grunt.template.process(tpls.ssh, {
-            data: {
-                host: config.ssh_host,
-                port: config.ssh_port
-            }
-        });
+
+        // Test whether an SSH port is defined and pass the default port '22' if it's not defined
+        if (typeof config.ssh_port === "undefined") {
+            var tpl_ssh = grunt.template.process(tpls.ssh, {
+                data: {
+                    host: config.ssh_host,
+                    port: '22'
+                }
+            });
+        } else {
+            var tpl_ssh = grunt.template.process(tpls.ssh, {
+                data: {
+                    host: config.ssh_host,
+                    port: config.ssh_port
+                }
+            });
+        }
 
         grunt.log.writeln("Importing DUMP into remote database");
 

--- a/lib/dbImport.js
+++ b/lib/dbImport.js
@@ -32,7 +32,8 @@ function dbImport(config, src) {
     } else { // it's a remote connection
         var tpl_ssh = grunt.template.process(tpls.ssh, {
             data: {
-                host: config.ssh_host
+                host: config.ssh_host,
+                port: config.ssh_port
             }
         });
 

--- a/lib/tpls.js
+++ b/lib/tpls.js
@@ -11,7 +11,7 @@ var tpls = {
 
     mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> -P<%= port %> <%= database %>",
 
-    ssh: "ssh <%= host %>",
+    ssh: "ssh -p <%= port %>  <%= host %>",
 
     mysqldump: "mysqldump -h <%= host %> -u<%= user %> -p<%= pass %> -P<%= port %> <%= database %> <%= ignoreTables %>"
 };


### PR DESCRIPTION
Custom SSH ports are supported on remote datasources with the “ssh_port” declaration.
