### PR TITLE
Do not store Password warning in db dump

### DIFF
--- a/tasks/deployments.js
+++ b/tasks/deployments.js
@@ -209,7 +209,7 @@ module.exports = function(grunt) {
         }
 
         // Capture output...
-        var output = shell.exec(cmd, {silent: true}).output;
+        var output = shell.exec(cmd, {silent: true}).output.replace( 'Warning: Using a password on the command line interface can be insecure.', '' );
 
         // Write output to file using native Grunt methods
         grunt.file.write( output_paths.file, output );


### PR DESCRIPTION
Hello,

Thanks for sharing your software. I use mysql56 from homebrew on a Mac, and when dumping local db 
"Warning: Using a password on the command line interface can be insecure." is added to the dump file, and then import fails. The way I've solved it here is obviously not fancy, but it does the trick for me.

Let me know if you need any help with merging this in or testing other use cases if you don't have access to an environment where you can reproduce this.
