### PR TITLE
Support for windows platform

### DIFF
--- a/lib/dbDump.js
+++ b/lib/dbDump.js
@@ -50,7 +50,7 @@ function dbDump(config, output_paths, noExec) {
             }
         });
 
-        cmd = tpl_ssh + " \\ " + tpl_mysqldump;
+        cmd = tpl_ssh + " " + tpl_mysqldump;
     }
 
     if (!noExec) {

--- a/lib/dbReplace.js
+++ b/lib/dbReplace.js
@@ -11,20 +11,12 @@ function dbReplace(search, replace, output_path, noExec) {
     // avoids overwriting original backup
     grunt.file.copy(output_path.file, output_path["file-tmp"]);
 
-    // Perform Search and replace on the temp file (not original)
-    var cmd = grunt.template.process( tpls.search_replace, {
-        data: {
-            search: search,
-            replace: replace,
-            path: output_path["file-tmp"]
-        }
-    });
-
     if ( grunt.file.exists(output_path["file-tmp"])) {
         // Execute cmd
         if (!noExec) {
             grunt.log.writeln("Replacing '" + search + "' with '" + replace + "' in the export (.sql) path.file.");
-            shell.exec(cmd);
+            //Execute SED
+            shell.sed("-i", search, replace, output_path["file-tmp"]);
             grunt.log.oklns("Database references succesfully updated.");
         }
     } else {
@@ -32,7 +24,7 @@ function dbReplace(search, replace, output_path, noExec) {
     }
 
     // Return for reference and test suite purposes
-    return cmd; 
+    return shell;
 }
 
 module.exports = dbReplace;

--- a/lib/dbReplace.js
+++ b/lib/dbReplace.js
@@ -15,8 +15,12 @@ function dbReplace(search, replace, output_path, noExec) {
         // Execute cmd
         if (!noExec) {
             grunt.log.writeln("Replacing '" + search + "' with '" + replace + "' in the export (.sql) path.file.");
-            //Execute SED
-            shell.sed("-i", search, replace, output_path["file-tmp"]);
+
+            var reg= new RegExp(search,"g");                            //Create a global regexp w/ search string
+            var myFile=grunt.file.read(output_path["file-tmp"]);        //Get file as a string
+            var result = myFile.replace(reg, replace);                  //Replace search string by replace string
+            grunt.file.write(output_path["file-tmp"], result);          //Write in file
+
             grunt.log.oklns("Database references succesfully updated.");
         }
     } else {

--- a/lib/tpls.js
+++ b/lib/tpls.js
@@ -5,8 +5,6 @@
  */
 var tpls = {
 
-	search_replace: "sed -i '' 's#<%= search %>#<%= replace %>#g' <%= path %>",
-
     backup_path: "<%= backups_dir %>/<%= env %>/<%= date %>/<%= time %>",
 
     mysql: "mysql -h <%= host %> -u <%= user %> -p<%= pass %> -P<%= port %> <%= database %>",

--- a/tasks/deployments.js
+++ b/tasks/deployments.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
         dbDump(local_options, local_backup_paths);
 
         // Search and Replace database refs
-        dbReplace( local_options.url, target_options.url, local_backup_paths.file );
+        dbReplace( local_options.url, target_options.url, local_backup_paths );
 
         // Dump target DB
         dbDump(target_options, target_backup_paths);


### PR DESCRIPTION
As you askes me, here's my version working on windows.
I was a little surprised by the develop branch having a totally different structure from master where I originally changed the code.
I have 2 points I'd want you to see:
- Try `dbDump`. I don't know if it still works on Linux without backslashes in cmd
- I don't know what to return in `dbReplace()` as there's no more cmd to return. Now I use shelljs sed command... so I thought you could return shell but I don't know what to do with unit testing.

I hope my contribution is useful and usable for you (and others).

However, thank you for this fantastic grunt plugin!
